### PR TITLE
Create IAM Role & SSM Parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+.terraform.lock.hcl

--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "jenkins_iam" {
+  source                = "../modules/iam"
+  instance_profile_name = "jenkins-profile-name"
+  iam_policy_name       = "jenkins-policy-name"
+  role_name             = "jenkins-role"
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,0 +1,41 @@
+resource "aws_iam_policy" "jenkins_iam_policy" {
+  name = var.iam_policy_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParameterByPath"
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role" "jenkins_role" {
+  name = var.role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy_attachment" "jenkins_role_policy_attachment" {
+  name       = "Policy Attachement"
+  policy_arn = aws_iam_policy.jenkins_iam_policy.arn
+  roles      = [aws_iam_role.jenkins_role.name]
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -39,3 +39,8 @@ resource "aws_iam_policy_attachment" "jenkins_role_policy_attachment" {
   policy_arn = aws_iam_policy.jenkins_iam_policy.arn
   roles      = [aws_iam_role.jenkins_role.name]
 }
+
+resource "aws_iam_instance_profile" "jenkins_instance_profile" {
+  name = var.instance_profile_name
+  role = aws_iam_role.jenkins_role.name
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,15 @@
+variable "instance_profile_name" {
+  type    = string
+  default = "example-instance-profile"
+}
+
+variable "iam_policy_name" {
+  type    = string
+  default = "example-policy"
+}
+
+variable "role_name" {
+  type    = string
+  default = "example-role"
+}
+

--- a/terraform/ssm/main.tf
+++ b/terraform/ssm/main.tf
@@ -1,0 +1,14 @@
+resource "aws_ssm_parameter" "ssh_private" {
+  name   = "/devops-tools/jenkins/id_rsa"
+  type   = "SecureString"
+  key_id = "alias/aws/ssm"
+  value  = file("/home/amin/.ssh/id_rsa")
+}
+
+resource "aws_ssm_parameter" "ssh_public" {
+  name   = "/devops-tools/jenkins/id_rsa.pub"
+  type   = "SecureString"
+  key_id = "alias/aws/ssm"
+  value  = file("/home/amin/.ssh/id_rsa.pub")
+
+}


### PR DESCRIPTION
Granting EC2 instances permissions to read secrets from AWS SSM (Systems Manager).
This PR also adds SSM parameters.