### PR TITLE
Add AWS EFS for cross AZ storage

### DIFF
--- a/terraform/efs/main.tf
+++ b/terraform/efs/main.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "efs_module" {
+  source     = "../modules/efs"
+  vpc_id     = "vpc-0a5ca4a92c2e10163"
+  subnet_ids = ["subnet-058a7514ba8adbb07", "subnet-0dbcd1ac168414927", "subnet-032f5077729435858"]
+}

--- a/terraform/modules/efs/main.tf
+++ b/terraform/modules/efs/main.tf
@@ -1,0 +1,34 @@
+resource "aws_security_group" "efs_sg" {
+  name_prefix = "efs-sg"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_efs_file_system" "jenkins" {
+  creation_token   = "jenkins"
+  encrypted        = true
+  performance_mode = "generalPurpose"
+  throughput_mode  = "bursting"
+  tags = {
+    Name = "jenkins-efs"
+  }
+}
+
+resource "aws_efs_mount_target" "jenkins" {
+  count           = length(var.subnet_ids)
+  file_system_id  = aws_efs_file_system.jenkins.id
+  subnet_id       = var.subnet_ids[count.index]
+  security_groups = [aws_security_group.efs_sg.id]
+}

--- a/terraform/modules/efs/variables.tf
+++ b/terraform/modules/efs/variables.tf
@@ -1,0 +1,5 @@
+variable "vpc_id" {}
+
+variable "subnet_ids" {
+  type = list(any)
+}


### PR DESCRIPTION
AWS EFS is a global filesystem service. It means it helps read and write backup files across AZs (and even regions).
In this PR we created an EFS with a mount target for each subnet. Each subnet is on a unique subnet for HA purposes.